### PR TITLE
care retry

### DIFF
--- a/lib/fluent/plugin/out_mackerel.rb
+++ b/lib/fluent/plugin/out_mackerel.rb
@@ -135,6 +135,7 @@ module Fluent
         end
       rescue => e
         log.error("out_mackerel:", :error_class => e.class, :error => e.message)
+        raise e
       end
     end
 

--- a/test/plugin/test_out_mackerel.rb
+++ b/test/plugin/test_out_mackerel.rb
@@ -69,6 +69,21 @@ class MackerelOutputTest < Test::Unit::TestCase
     out_keys val1,val2
   ]
 
+  CONFIG_BUFFER_LIMIT_DEFAULT = %[
+    type mackerel
+    service xyz
+    api_key 123456
+    out_keys val1,val2,val3
+  ]
+
+  CONFIG_BUFFER_LIMIT_IGNORE = %[
+    type mackerel
+    service xyz
+    api_key 123456
+    out_keys val1,val2,val3
+    buffer_chunk_limit 1k
+  ]
+
   def create_driver(conf = CONFIG, tag='test')
     Fluent::Test::BufferedOutputTestDriver.new(Fluent::MackerelOutput, tag).configure(conf)
   end
@@ -107,6 +122,13 @@ class MackerelOutputTest < Test::Unit::TestCase
     d = create_driver(CONFIG_OUT_KEY_PATTERN)
     assert_match d.instance.instance_variable_get(:@out_key_pattern), "val1"
     assert_no_match d.instance.instance_variable_get(:@out_key_pattern), "foo"
+
+    d = create_driver(CONFIG_BUFFER_LIMIT_DEFAULT)
+    assert_equal d.instance.instance_variable_get(:@buffer_chunk_limit), Fluent::MackerelOutput::MAX_BUFFER_CHUNK_LIMIT
+    assert_equal d.instance.instance_variable_get(:@buffer_queue_limit), 4096
+
+    d = create_driver(CONFIG_BUFFER_LIMIT_IGNORE)
+    assert_equal d.instance.instance_variable_get(:@buffer_chunk_limit), Fluent::MackerelOutput::MAX_BUFFER_CHUNK_LIMIT
   end
 
   def test_write


### PR DESCRIPTION
In current inplementtion, chunk is abondoned when posting failed.
`write` method should be atomic (success or not at single request) and raise error when failing.

In this patch, value of default chunk_limit is limited to 100k and raise error when failed posting metrics.