### PR TITLE
add `remove_prefix` option for remove "custom" when sending service metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,21 @@ You can also send ["service" metric](http://help-ja.mackerel.io/entry/spec/api/v
   out_keys 2xx_count,3xx_count,4xx_count,5xx_count
 </match>
 ```
+
+When you send service metric, "custom" can be removed with `remove_prefix` as follows.
+This option is not availabe when sending host metric.
+
+```
+<match ...>
+  type mackerel
+  api_key 123456
+  service yourservice
+  remove_prefix
+  metrics_name http_status.${out_key}
+  out_keys 2xx_count,3xx_count,4xx_count,5xx_count
+</match>
+```
+
 `flush_interval` is not allowed to be set less than 60 secs not to send API requests more than once in a minute.
 
 This plugin overwrites the default value of `buffer_queue_limit` and `buffer_chunk_limit` as follows.

--- a/lib/fluent/plugin/out_mackerel.rb
+++ b/lib/fluent/plugin/out_mackerel.rb
@@ -8,6 +8,7 @@ module Fluent
     config_param :hostid, :string, :default => nil
     config_param :hostid_path, :string, :default => nil
     config_param :service, :string, :default => nil
+    config_param :remove_prefix, :bool, :default => false
     config_param :metrics_name, :string, :default => nil
     config_param :out_keys, :string, :default => nil
     config_param :out_key_pattern, :string, :default => nil
@@ -58,6 +59,10 @@ module Fluent
 
       if @hostid and @service
         raise Fluent::ConfigError, "Niether 'hostid' and 'service' cannot be specifed."
+      end
+
+      if @remove_prefix and @service.nil?
+        raise Fluent::ConfigError, "'remove_prefix' must be used with 'service'."
       end
 
       unless @hostid.nil?
@@ -115,7 +120,7 @@ module Fluent
           metric = {
             'value' => record[key].to_f,
             'time' => time,
-            'name' => "%s.%s" % ['custom', name]
+            'name' => @remove_prefix ? name : "%s.%s" % ['custom', name]
           }
           metric['hostId'] = @hostid_processor.call(:tokens => tokens) if @hostid
           metrics << metric


### PR DESCRIPTION
Service metric of Mackerel does not require "custom" prefix, but fluent-plugin-mackerel add "custom" prefix for both host metric and service metric.

With `remove_prefix` option, "custom" prefix will not be added. This option is available only when sending service metic.

This resolves #8.

